### PR TITLE
fix(api): enforce network permissions on certificate sign/create endpoints

### DIFF
--- a/backend/api/certificates.py
+++ b/backend/api/certificates.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from ..auth.oidc import require_user, UserInfo
+from ..auth.permissions import check_network_permission
 from ..config import settings
 from ..database import get_session
 from pathlib import Path
@@ -20,6 +21,35 @@ from ..services.ip_allocator import IPAllocator
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/certificates", tags=["certificates"])
+
+
+async def _require_manage_nodes(
+    user: UserInfo,
+    network_id: int,
+    session: AsyncSession,
+) -> Optional[User]:
+    """
+    Ensure the current user may issue certificates for this network.
+
+    System admins are always allowed. Other users must have the
+    manage_nodes permission (or be owner) on the network, mirroring the
+    node-requests approval workflow. Raises 403 otherwise.
+    Returns the DB user (or None for system admins without a DB row).
+    """
+    user_result = await session.execute(select(User).where(User.oidc_sub == user.sub))
+    db_user = user_result.scalar_one_or_none()
+
+    if user.system_role == "system-admin":
+        return db_user
+
+    if db_user is None or not await check_network_permission(
+        db_user.id, network_id, "manage_nodes", session
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="You don't have permission to issue certificates for this network",
+        )
+    return db_user
 
 
 class SignRequest(BaseModel):
@@ -92,6 +122,8 @@ async def sign_certificate(
     network = result.scalar_one_or_none()
     if not network:
         raise HTTPException(status_code=404, detail="Network not found")
+
+    await _require_manage_nodes(user, body.network_id, session)
 
     cert_manager = CertManager(session)
     duration = body.duration_days or settings.default_cert_expiry_days
@@ -186,6 +218,8 @@ async def create_certificate(
     network = result.scalar_one_or_none()
     if not network:
         raise HTTPException(status_code=404, detail="Network not found")
+
+    await _require_manage_nodes(user, body.network_id, session)
 
     # First node in network must be a lighthouse
     count_result = await session.execute(


### PR DESCRIPTION
## Problem

`POST /api/certificates/sign` and `POST /api/certificates/create` only require
`require_user` — any authenticated user can issue a certificate into **any**
network, and can choose their own firewall `group` in the request body.

This bypasses two access-control mechanisms that already exist in the codebase:

- the per-network permission model (`NetworkPermission`, owner/member,
  `can_manage_nodes`), which *is* enforced on `/api/nodes`, `/api/node-requests`,
  etc.
- the `/api/node-requests` request→approve workflow and the per-network
  `auto_approve_nodes` setting, which a user can skip entirely by calling
  `/api/certificates/sign` directly (the sign endpoint auto-creates the node).

Impact: any account in the OIDC realm (or anyone with a dev token when
`DEBUG=true`) can join any mesh network with any group, regardless of network
membership. Since the bundled Keycloak realm ships with
`registrationAllowed: true`, a default deployment reachable by untrusted
parties allows self-registration straight into certificate issuance.

## Fix

Add a `_require_manage_nodes()` helper in `backend/api/certificates.py` and
call it in both endpoints after the network lookup:

- `system-admin` (system role) → allowed, matching existing conventions
  (e.g. `node_requests.py`)
- otherwise the user must have `manage_nodes` permission (or be `owner`) on
  the target network, checked via the existing
  `auth.permissions.check_network_permission()`
- otherwise → `403`

This mirrors exactly the check used by the node-requests approval endpoints,
so the direct-sign path now requires the same privilege as approving a node
request.

## Notes / open questions

- Should non-admin users without `manage_nodes` be redirected to the
  `/api/node-requests` flow instead (respecting `auto_approve_nodes`)? This PR
  keeps the change minimal and only closes the authorization gap; happy to
  follow up with a request-flow integration if preferred.
- No migration needed; purely an authorization check.

## Testing

- `python -m py_compile backend/api/certificates.py` passes.
- Manual: member user without `manage_nodes` on network A → `/sign` returns
  403; owner of network A → succeeds; system-admin → succeeds on any network.