### PR TITLE
fix(api): enforce node access check on POST /api/device/enrollment-codes

### DIFF
--- a/backend/api/device.py
+++ b/backend/api/device.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.oidc import require_user, require_device_token, UserInfo, create_device_token
+from ..auth.permissions import get_user_nodes
 from ..config import settings
 from ..database import get_session
 from ..models import Network, NetworkDNSConfig, Node, EnrollmentCode, User
@@ -60,6 +61,12 @@ async def create_enrollment_code(
     result = await session.execute(select(Node).where(Node.id == body.node_id))
     node = result.scalar_one_or_none()
     if not node:
+        raise HTTPException(status_code=404, detail="Node not found")
+    # An enrollment code is redeemable for a device token, which grants access to this
+    # node's config and certificate bundle. Apply the same access check that
+    # GET /api/nodes/{node_id}/certs uses before serving that same material.
+    node_ids = await get_user_nodes(user, session, network_id=node.network_id)
+    if node.id not in node_ids:
         raise HTTPException(status_code=404, detail="Node not found")
     if not node.ip_address:
         raise HTTPException(


### PR DESCRIPTION
## Problem

`POST /api/device/enrollment-codes` (`backend/api/device.py`) is guarded only by
`Depends(require_user)`. It looks up the node by the caller-supplied `node_id`
and mints a one-time `EnrollmentCode` for it without checking that the caller has
any relationship to that node or its network.

An enrollment code is redeemable at the public `POST /api/device/enroll` for a
device token, and that token grants `GET /api/device/certs`, which returns the
node's `ca.crt`, `host.crt` and — when the key is server-held (nodes created via
`POST /api/certificates/create`) — `host.key`. It also grants
`GET /api/device/config`, the node's full generated Nebula config.

So any authenticated account can currently walk `node_id` values, mint a code for
a node in a network it has no membership in, redeem it, and pull that node's
credentials. Redeeming also bumps `device_token_version`, which invalidates the
real device's token — so it is a denial of service against that node as well,
even when the key is client-held.

The same certificate bundle is already served by `GET /api/nodes/{node_id}/certs`,
and *that* endpoint is access-checked (`_ensure_user_can_access_node`,
`backend/api/nodes.py:65`). The device endpoint that hands out a code for the same
material simply never got the equivalent check.

## Fix

Apply the same access check `GET /api/nodes/{node_id}/certs` uses, immediately
after the node lookup:

```python
node_ids = await get_user_nodes(user, session, network_id=node.network_id)
if node.id not in node_ids:
    raise HTTPException(status_code=404, detail="Node not found")
```

`get_user_nodes` (`backend/auth/permissions.py`) already honours both
`NetworkPermission` and per-node `NodePermission`, so this deliberately does **not**
introduce a new privilege level — it makes the enrollment-code endpoint exactly as
permissive as the endpoint that serves the bundle, and no more.

Two consequences worth calling out:

- It intentionally uses `get_user_nodes` rather than requiring `manage_nodes`.
  Requiring `manage_nodes` would be *stricter* than `GET /api/nodes/{node_id}/certs`,
  which today hands the identical `host.key` to any member of the network, so it
  would break existing members' enrollment flow (the Enroll / Re-Enroll buttons in
  `frontend/src/pages/Nodes.tsx` are not permission-gated) without actually reducing
  their access to the secret. Happy to tighten both endpoints together in a follow-up
  if you'd prefer `manage_nodes` here.
- It returns the same `404 "Node not found"` as the existing missing-node branch
  rather than a `403`, matching the documented convention in
  `_ensure_user_can_access_node` ("Raise 404 if the current user cannot access the
  given node") and avoiding a node-ID enumeration oracle.

+7 / −0, one file, no reordering of existing statements, no migration.

## Testing

Verified against a live app instance (`TestClient`, seeded SQLite) with eight
caller identities, asserting both the outcome *and* parity with
`GET /api/nodes/{node_id}/certs`:

| caller | before | after | `GET /api/nodes/{id}/certs` |
|---|---|---|---|
| network owner (`manage_nodes`) | allowed | allowed | allowed |
| plain member, **no** `manage_nodes` | allowed | allowed | allowed |
| per-node `NodePermission` only | allowed | allowed | allowed |
| standalone/dev user (`sub="dev"`) | allowed | allowed | allowed |
| **owner of a different network** | **allowed** | **404** | 404 |
| **authenticated, zero permissions** | **allowed** | **404** | 404 |
| **no `User` row at all** | **allowed** | **404** | 404 |
| **system-admin with no permission/grant** | **allowed** | **404** | 404 |

Also verified:

- Every node returned by `GET /api/nodes` for a given caller is still enrollable by
  that caller — i.e. no button in the existing UI can now fail, since the Nodes page
  and this endpoint resolve access through the same function.
- Unchanged for authorized callers: node without a certificate still returns
  `400 "Node has no certificate yet. Create a certificate first."`; a nonexistent
  `node_id` still returns `404`; the happy path still returns a 16-character code
  with `node_id` and `hostname`.
- `python -m py_compile backend/api/device.py` passes; `bandit` on the file reports
  no issues.

## Notes

- Independent of #2 — that PR touches `backend/api/certificates.py` only, this one
  touches `backend/api/device.py` only, so they apply cleanly in either order.
- Every other route in `backend/api/device.py` derives its `node_id` from
  `require_device_token` rather than from the request body, so this was the only
  endpoint in the file with this gap.